### PR TITLE
More performance improvements

### DIFF
--- a/cardano-diagnosis-program.cabal
+++ b/cardano-diagnosis-program.cabal
@@ -41,7 +41,6 @@ library
     , bytestring
     , containers
     , directory
-    , mtl
     , safe-exceptions
     , text
   exposed-modules:

--- a/src/Classifier.hs
+++ b/src/Classifier.hs
@@ -6,6 +6,7 @@ module Classifier
        ) where
 
 import qualified Data.ByteString.Lazy     as LBS
+import           Data.List                (foldl')
 import qualified Data.Map.Strict          as Map
 import           Data.Text.Encoding.Error (ignore)
 import qualified Data.Text.Lazy           as LT
@@ -15,17 +16,17 @@ import           Types                    (Analysis, Knowledge (..))
 
 -- | Analyze each log file based on the knowlodgebases' data.
 extractIssuesFromLogs :: [LBS.ByteString] -> Analysis -> Analysis
-extractIssuesFromLogs files analysis = filterAnalysis $ foldr runClassifiers analysis files
+extractIssuesFromLogs files analysis = filterAnalysis $ foldl' runClassifiers analysis files
 
 -- | Run analysis on given file
-runClassifiers :: LBS.ByteString -> Analysis -> Analysis
-runClassifiers logfile analysis =
+runClassifiers :: Analysis -> LBS.ByteString -> Analysis
+runClassifiers analysis logfile =
     let logLines = LT.lines $ LT.decodeUtf8With ignore logfile
-    in foldr analyzeLine analysis logLines
+    in foldl' analyzeLine analysis logLines
 
 -- | Analyze each line
-analyzeLine :: LT.Text -> Analysis -> Analysis
-analyzeLine str = Map.mapWithKey (compareWithKnowledge str)
+analyzeLine :: Analysis -> LT.Text -> Analysis
+analyzeLine analysis str = Map.mapWithKey (compareWithKnowledge str) analysis
 
 -- | Compare the line with knowledge lists
 compareWithKnowledge :: LT.Text -> Knowledge -> [LT.Text] -> [LT.Text]
@@ -34,6 +35,6 @@ compareWithKnowledge str Knowledge{..} xs =
     then str : xs
     else xs
 
--- | Filter out any record that has empty (i.e couldn't catch any string related)
+-- | Filter out any records that are empty (i.e couldn't catch any string related)
 filterAnalysis :: Analysis -> Analysis
 filterAnalysis = Map.filter (/= [])

--- a/src/HtmlReportGenerator/Generator.hs
+++ b/src/HtmlReportGenerator/Generator.hs
@@ -104,6 +104,7 @@ generateErrorReport e = do
     main ! A.class_ "container" $
       renderHelpSection
 
+-- | Render header for error message
 renderErrorHeader :: ExtractorException -> Html
 renderErrorHeader e =
   div ! A.class_ "jumbotron bg-warning" $

--- a/src/HtmlReportGenerator/Solution.hs
+++ b/src/HtmlReportGenerator/Solution.hs
@@ -15,7 +15,7 @@ import           Types                       (ErrorCode (..))
 -- | Render solution section of the generated report
 --
 -- This is temporal workaround for rendering solutions
---this will be deprecated in the future version.
+-- this will be deprecated in the future version.
 renderSolution :: ErrorCode -> LT.Text -> Html
 renderSolution TimeSync      t = renderTimeSync t
 renderSolution StaleLockFile t = renderStaleLockFile t

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -32,10 +32,10 @@ data ErrorCode
 
 -- | Record identifying the issue
 data Knowledge = Knowledge
-  {  kErrorText :: !LT.Text    -- ^ Text used for matching error lines
-  ,  kErrorCode :: !ErrorCode  -- ^ Identity for error code
-  ,  kProblem   :: !LT.Text    -- ^ Text describing what is the problem
-  ,  kSolution  :: !LT.Text    -- ^ Text describing how to solve the issue
+  {  kErrorText :: !LT.Text   -- ^ Text used for matching error lines
+  ,  kErrorCode :: !ErrorCode -- ^ Identity for error code
+  ,  kProblem   :: !LT.Text   -- ^ Text describing what is the problem
+  ,  kSolution  :: !LT.Text   -- ^ Text describing how to solve the issue
   }
 
 -- | Map used to collect error lines


### PR DESCRIPTION
This PR will introduce more performance improvements. 
```
hiroto@hiroto-XPS-13-9360:~/haskell/cardano-diagnosis-program$ stack exec diagnosis "/home/hiroto/Downloads/logs (6).zip" -- +RTS -s
Running analysis on logs
Analysis done successfully!! See result-2018-04-20.html
   2,007,349,528 bytes allocated in the heap
       7,874,352 bytes copied during GC
      21,629,944 bytes maximum residency (11 sample(s))
         424,800 bytes maximum slop
              45 MB total memory in use (9 MB lost due to fragmentation)
```